### PR TITLE
Setting custom HTTP codes for application exceptions

### DIFF
--- a/test/PhlyRestfullyTest/ApiProblemTest.php
+++ b/test/PhlyRestfullyTest/ApiProblemTest.php
@@ -40,6 +40,15 @@ class ApiProblemTest extends TestCase
         $this->assertEquals($status, $payload['httpStatus']);
     }
 
+    public function testExceptionCodeIsUsedForHttpStatus()
+    {
+        $exception  = new \Exception('exception message', 401);
+        $apiProblem = new ApiProblem('500', $exception);
+        $payload    = $apiProblem->toArray();
+        $this->assertArrayHasKey('httpStatus', $payload);
+        $this->assertEquals($exception->getCode(), $payload['httpStatus']);
+    }
+
     public function testDetailStringIsUsedVerbatim()
     {
         $apiProblem = new ApiProblem('500', 'foo');


### PR DESCRIPTION
I've found necessity to return custom status codes in REST response for exceptions thrown by application.
Currently library supports only setting status codes for REST methods. In custom ones it is not checked and returned as **500** - **Internal Server Error**. Another issue is that also in REST methods there are only some declared exceptions, which are handled - for example in `getList()` there is none, so only failed response from API will be **500**.

I've added method to check if exception code is set, and if yes, then **statusCode** is overwritten. 

There might be better solution for problem, but so far I have no other idea. Maybe there would be some basic exception class from which other will inherit, and in resource controller catching will be compared with that class instance.
In that way I have no idea how to handle exception from every custom line of code, not only from REST methods.
