### PR TITLE
Add custom Accept header handling for */json type

### DIFF
--- a/src/PhlyRestfully/Listener/ApiProblemListener.php
+++ b/src/PhlyRestfully/Listener/ApiProblemListener.php
@@ -71,7 +71,15 @@ class ApiProblemListener implements ListenerAggregateInterface
 
         // ... that matches certain criteria
         $accept = $headers->get('Accept');
-        if (!$accept->match('*/json')) {
+        $matched = false;
+        foreach ($headers->get('Accept')->getPrioritized() as $check) {
+            if ($check->format == 'json' || $check->format == '*') {
+                $matched = true;
+                break;
+            }
+        }
+
+        if (!$matched) {
             return;
         }
 


### PR DESCRIPTION
Add custom Accept header handling for */json type

The default Accept header match() function will match `*/json` against anything, as it sees the main type as wildcard `*`, returning immediately and ignoring the format of `json`.

This PR implements a custom check that will match `*/json` as expected.

Will match:
`application/json`
`application/api-problem+json`
`example/json`
Will _not_ match:
`application/json+text`

Another possibility is to just attempt to match against `application/json`.

Comments @weierophinney ?
