### PR TITLE
Track attached events

### DIFF
--- a/src/PhlyRestfully/Listener/ApiProblemListener.php
+++ b/src/PhlyRestfully/Listener/ApiProblemListener.php
@@ -35,7 +35,7 @@ class ApiProblemListener implements ListenerAggregateInterface
      */
     public function attach(EventManagerInterface $events)
     {
-        $events->attach(MvcEvent::EVENT_RENDER, __CLASS__ . '::onRender', 1000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER, __CLASS__ . '::onRender', 1000);
     }
 
     /**


### PR DESCRIPTION
You can now detach the listener with the detach() function, as per
ListenerAggregateInterface.
Signed-off-by: Michael Gooden michael@bluepointweb.com
