### PR TITLE
[Fix #11] Only attach ApiProblemListener to API Controllers

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -118,7 +118,11 @@ class Module
         $services = $app->getServiceManager();
         $events   = $app->getEventManager();
         $events->attach('render', array($this, 'onRender'), 100);
-        $events->attach($services->get('PhlyRestfully\ApiProblemListener'));
+        $sharedEvents = $events->getSharedManager();
+        $sharedEvents->attach('PhlyRestfully\ResourceController', 'dispatch', function($e) {
+            $eventManager = $e->getApplication()->getEventManager();
+            $eventManager->attach($e->getApplication()->getServiceManager()->get('PhlyRestfully\ApiProblemListener'));
+        }, 300);
     }
 
     /**


### PR DESCRIPTION
Fixes #11.

If you need want to use `ApiProblemListener` in a non `ResourceController`
controller, have your controller emit `PhlyRestfully\RestfulJsonStrategy` or
attach the `ApiProblemListener` to your controller.
