### PR TITLE
Made acceptFilter static and updated references...

### DIFF
--- a/src/PhlyRestfully/Listener/ApiProblemListener.php
+++ b/src/PhlyRestfully/Listener/ApiProblemListener.php
@@ -30,7 +30,7 @@ class ApiProblemListener implements ListenerAggregateInterface
      *
      * @var string
      */
-    static protected $acceptFilter = 'application/hal+json,application/api-problem+json,application/json';
+    protected static $acceptFilter = 'application/hal+json,application/api-problem+json,application/json';
 
     /**
      * @var \Zend\Stdlib\CallbackHandler[]


### PR DESCRIPTION
Made acceptFilter static and updated references by changing $this->acceptFilter to self::$acceptFilter.  This addresses (hopefully) issue #17, which is caused because onRender(), which is static, tries to use acceptFilter as if its in the context of an object.
