### PR TITLE
Override getIdentifier to allow for custom resource identifiers

### DIFF
--- a/src/PhlyRestfully/ResourceController.php
+++ b/src/PhlyRestfully/ResourceController.php
@@ -112,6 +112,13 @@ class ResourceController extends AbstractRestfulController
     protected $route;
 
     /**
+     * Name of the param that should be used as the resource identifier.
+     *
+     * @var string
+     */
+    protected $resourceIdentifierParam = 'id';
+
+    /**
      * Constructor
      *
      * Allows you to set the event identifier, which can be useful to allow multiple
@@ -124,6 +131,26 @@ class ResourceController extends AbstractRestfulController
         if (null !== $eventIdentifier) {
             $this->eventIdentifier = $eventIdentifier;
         }
+    }
+
+    /**
+     * Get the param used to identify the resource in the route
+     *
+     * @return string
+     */
+    public function getResourceIdentifierParam()
+    {
+        return $this->resourceIdentifierParam;
+    }
+
+    /**
+     * Set the resource identifier param
+     *
+     * @param string $param
+     */
+    public function setResourceIdentifierParam($param)
+    {
+        $this->resourceIdentifierParam = $param;
     }
 
     /**
@@ -650,6 +677,9 @@ class ResourceController extends AbstractRestfulController
         return $response;
     }
 
+    /**
+     * @param LinkCollectionAwareInterface $resource
+     */
     protected function injectSelfLink(LinkCollectionAwareInterface $resource)
     {
         $self = new Link('self');
@@ -658,5 +688,32 @@ class ResourceController extends AbstractRestfulController
             $self->setRouteParams(array('id' => $resource->id));
         }
         $resource->getLinks()->add($self);
+    }
+
+    /**
+     * @param \Zend\Mvc\Router\RouteMatch   $routeMatch
+     * @param \Zend\Stdlib\RequestInterface $request
+     *
+     * @return string|bool
+     */
+    protected function getIdentifier($routeMatch, $request)
+    {
+        $id = $routeMatch->getParam($this->getResourceIdentifierParam(), false);
+
+        if ($id) {
+
+            return $id;
+        }
+
+        // Should we really allow this ?
+        // If we remove it it's a BC break
+        $id = $request->getQuery()->get($this->getResourceIdentifierParam(), false);
+
+        if ($id) {
+
+            return $id;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Heya!

No better way to explain why then with a use case!

Assume you have a resource farms with the route /farms[/:id] and that farms has an association tractors. One would assumes the route/link /farms/:id/tractors and that their is a match resource tractors with the route /tractors[/:id]

Using a literal child route on farms to make this possible :id is already being used and will be define by the farm ID thus the ResourceController assumes a get instead of a getList and we don't get all the nice handling of Zend\Pagination\Pagination for our collection as one would hope.

On the downside it allows people to create very long routes /farms/1/tractors/1/drivers/1/children and so on. I don't know what you think of this ?
