### PR TITLE
Add links to resources inside the resources in an HalCollection

### DIFF
--- a/src/PhlyRestfully/Plugin/HalLinks.php
+++ b/src/PhlyRestfully/Plugin/HalLinks.php
@@ -537,8 +537,8 @@ class HalLinks extends AbstractHelper implements
 
     /**
      * Extract a collection as an array
-     * 
-     * @param  HalCollection $halCollection 
+     *
+     * @param  HalCollection $halCollection
      * @return array
      */
     protected function extractCollection(HalCollection $halCollection)

--- a/test/PhlyRestfullyTest/Plugin/HalLinksTest.php
+++ b/test/PhlyRestfullyTest/Plugin/HalLinksTest.php
@@ -136,7 +136,7 @@ class HalLinksTest extends TestCase
                 (object) array('id' => 'foo', 'name' => 'foo'),
                 (object) array('id' => 'bar', 'name' => 'bar'),
                 (object) array('id' => 'baz', 'name' => 'baz'),
-            ), 
+            ),
             'hostname/contacts'
         );
         $resource = new HalResource(


### PR DESCRIPTION
This is a question (sorry about the recursive title).

Problem: We have the necessity to return links to other resources inside the resources listed by a getList().
Example: I want all the schools in my city (getList() in the controller) and inside each of them links to all the classroom they have.

We are having a problem trying to add Links inside the resources returned from an HalCollection. In the listener we can return an array or an HalCollection (containing an array) without problems, but it's not allowed to us to give HalCollection an array of HalResource (for what we could find out). Without access to the HalResource object we could not find a way to add other links (that are not self) to them. Even if we attach ourself to various trigger in the work-flow we are unable to do it. For what we found out is in the renderer (and specifically in HalLinks) that the collection is parsed and translated to HalResources. HalCollections also have no setter for the main content, so we will probably have to extend the class.

We tried also using the new "child resources" capability of the library, but we decided that we don't like the work-flow (this is just about our code logic, not a comment about the functionality or how it is implemented).

We would like an advice to how to solve our problem. Maybe (probably) we are missing something. Thank you for the time you can dedicate to our question.

Fabrizio
