### PR TITLE
Location header is not set correctly for resource creation

### DIFF
--- a/src/PhlyRestfully/Plugin/HalLinks.php
+++ b/src/PhlyRestfully/Plugin/HalLinks.php
@@ -325,6 +325,47 @@ class HalLinks extends AbstractHelper implements
     }
 
     /**
+     * Create a URL from a Link
+     *
+     * @param  Link $linkDefinition
+     * @return string
+     * @throws Exception\DomainException if Link is incomplete
+     */
+    public function fromLink(Link $linkDefinition)
+    {
+        if (!$linkDefinition->isComplete()) {
+            throw new Exception\DomainException(sprintf(
+                'Link from resource provided to %s was incomplete; must contain a URL or a route',
+                __METHOD__
+            ));
+        }
+
+        if ($linkDefinition->hasUrl()) {
+            return array(
+                'href' => $linkDefinition->getUrl(),
+            );
+        }
+
+        $path = call_user_func(
+            $this->urlHelper,
+            $linkDefinition->getRoute(),
+            $linkDefinition->getRouteParams(),
+            $linkDefinition->getRouteOptions(),
+            true
+        );
+
+        if (substr($path, 0, 4) == 'http') {
+            return array(
+                'href' => $path,
+            );
+        }
+
+        return array(
+            'href' => call_user_func($this->serverUrlHelper, $path),
+        );
+    }
+
+    /**
      * Generate HAL links from a LinkCollection
      *
      * @param  LinkCollection $collection
@@ -450,47 +491,6 @@ class HalLinks extends AbstractHelper implements
         }
 
         return true;
-    }
-
-    /**
-     * Create a URL from a Link
-     *
-     * @param  Link $linkDefinition
-     * @return string
-     * @throws Exception\DomainException if Link is incomplete
-     */
-    protected function fromLink(Link $linkDefinition)
-    {
-        if (!$linkDefinition->isComplete()) {
-            throw new Exception\DomainException(sprintf(
-                'Link from resource provided to %s was incomplete; must contain a URL or a route',
-                __METHOD__
-            ));
-        }
-
-        if ($linkDefinition->hasUrl()) {
-            return array(
-                'href' => $linkDefinition->getUrl(),
-            );
-        }
-
-        $path = call_user_func(
-            $this->urlHelper,
-            $linkDefinition->getRoute(),
-            $linkDefinition->getRouteParams(),
-            $linkDefinition->getRouteOptions(),
-            true
-        );
-
-        if (substr($path, 0, 4) == 'http') {
-            return array(
-                'href' => $path,
-            );
-        }
-
-        return array(
-            'href' => call_user_func($this->serverUrlHelper, $path),
-        );
     }
 
     /**

--- a/src/PhlyRestfully/ResourceController.php
+++ b/src/PhlyRestfully/ResourceController.php
@@ -347,13 +347,12 @@ class ResourceController extends AbstractRestfulController
         }
 
         $this->injectSelfLink($resource);
+        $self = $resource->getLinks()->get('self');
+        $self = $this->plugin('HalLinks')->fromLink($self);
 
         $response = $this->getResponse();
         $response->setStatusCode(201);
-        $response->getHeaders()->addHeaderLine(
-            'Location',
-            $this->halLinks()->createLink($this->route, $resource->id, $resource->resource)
-        );
+        $response->getHeaders()->addHeaderLine('Location', $self);
 
         $events->trigger('create.post', $this, array('data' => $data, 'resource' => $resource));
 


### PR DESCRIPTION
I have the following routes:

```

return array(
    'router' => array(
        'routes' => array(
            'user' => array(
                'type' => 'Segment',
                'options' => array(
                    'route' => '/users[/:userId]',
                    'defaults' => array(
                        'controller' => 'User\Controller\User',
                    ),
                ),
                'may_terminate' => true,
                'child_routes' => array(
                    'address' => array(
                        'type' => 'Segment',
                        'options' => array(
                            'route' => '/addresses[/:addressId]',
                            'defaults' => array(
                                'controller' => 'User\Controller\UserAddress',
                            ),
                        ),
                    ),
                ),
            ),
        ),
    ),
);
```

The identifier name is userId instead of id to be able to add child routes. In the UserResource onCreate method:

```
  public function onCreate(ResourceEvent $e)
    {
        // ... some stuff here

        return array('id' => $user->getId());
    }
```

The HAL _self link is rendered correctly. But the code for the location header sets the route param with key "id" instead of the identifier_name which I set to "userId". That's why the location path will be "/users", instead of "/users/1" what is should be.

ResourceController.php line 353:

```
$response->getHeaders()->addHeaderLine(
            'Location',
            $this->halLinks()->createLink($this->route, $resource->id, $resource->resource)
        );
```
