### PR TITLE
Allow configurable ResourceController implementations.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,9 +7,10 @@
  */
 
 return array(
-    'phlyrestfully' => array(
-        'renderer'  => array(),
-        'resources' => array()
+    'phlyrestfully'       => array(
+        'renderer'        => array(),
+        'resources'       => array(),
+        'controllerClass' => 'PhlyRestfully\ResourceController'
     ),
 
     'service_manager' => array(

--- a/src/PhlyRestfully/Factory/ResourceControllerFactory.php
+++ b/src/PhlyRestfully/Factory/ResourceControllerFactory.php
@@ -81,9 +81,10 @@ class ResourceControllerFactory implements AbstractFactoryInterface
      */
     public function createServiceWithName(ServiceLocatorInterface $controllers, $name, $requestedName)
     {
-        $services = $controllers->getServiceLocator();
-        $config   = $services->get('Config');
-        $config   = $config['phlyrestfully']['resources'][$requestedName];
+        $services        = $controllers->getServiceLocator();
+        $config          = $services->get('Config');
+        $controllerClass = $config['phlyrestfully']['controllerClass'];
+        $config          = $config['phlyrestfully']['resources'][$requestedName];
 
         if ($services->has($config['listener'])) {
             $listener = $services->get($config['listener']);
@@ -120,7 +121,15 @@ class ResourceControllerFactory implements AbstractFactoryInterface
         }
 
         $events     = $services->get('EventManager');
-        $controller = new ResourceController($identifier);
+        $controller = new $controllerClass($identifier);
+
+        if (!$controller instanceof ResourceController) {
+            throw new ServiceNotCreatedException(sprintf(
+                '"%s" must be an implementation of PhlyRestfully\ResourceController',
+                $controllerClass
+            ));
+        }
+
         $controller->setEventManager($events);
         $controller->setResource($resource);
         $this->setControllerOptions($config, $controller);


### PR DESCRIPTION
This allows a different class to be specified to replace
PhlyRestfully\ResourceController when constructing controllers through
the factory.  A restriction is kept to ensure that the replacement
controller extends the original controller.

This allows users of PhlyRestfully to further configure the behaviour of
the controller if necessary.
- Modification to default configuration add a new "controllerClass"
  parameter, defaulting to the current ResourceController.
- Modification to the factory to construct the specified class instead
  the hard coded PhlyRestfully\ResourceController.
