### PR TITLE
Removes array to object casting; more flexible, consistent with docs.

### DIFF
--- a/src/PhlyRestfully/Resource.php
+++ b/src/PhlyRestfully/Resource.php
@@ -176,10 +176,7 @@ class Resource implements ResourceInterface
      */
     public function create($data)
     {
-        if (is_array($data)) {
-            $data = (object) $data;
-        }
-        if (!is_object($data)) {
+        if (!is_object($data) && !is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Data provided to create must be either an array or object; received "%s"',
                 gettype($data)
@@ -217,10 +214,7 @@ class Resource implements ResourceInterface
      */
     public function update($id, $data)
     {
-        if (is_array($data)) {
-            $data = (object) $data;
-        }
-        if (!is_object($data)) {
+        if (!is_object($data) && !is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 'Data provided to update must be either an array or object; received "%s"',
                 gettype($data)
@@ -308,12 +302,9 @@ class Resource implements ResourceInterface
      */
     public function patch($id, $data)
     {
-        if (is_array($data)) {
-            $data = (object) $data;
-        }
-        if (!is_object($data)) {
+        if (!is_object($data) && !is_array($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
-                'Data provided to create must be either an array or object; received "%s"',
+                'Data provided to patch must be either an array or object; received "%s"',
                 gettype($data)
             ));
         }


### PR DESCRIPTION
PUT, POST and PATCH methods currently have documentation and exceptions indicating that both objects and arrays can be provided, but in each case any provided objects will be cast into an array.

The default behaviour of the AbtstractRestfulController, and therefore the PhlyRestfully/ResourceController, is to unencode json data as it's provided, so arrays are decoded as arrays and objects as objects.

Sticking with this, rather than always modifying to an object, allows more flexibility in the listeners (e.g. listening for an array for create to create a collection of resources, vs an object to create just one).
