### PR TITLE
Convert provided array data to ArrayObject instead of StdClass.

### DIFF
--- a/src/PhlyRestfully/Resource.php
+++ b/src/PhlyRestfully/Resource.php
@@ -13,6 +13,7 @@ use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Stdlib\Parameters;
+use ArrayObject;
 
 /**
  * Base resource class
@@ -176,8 +177,9 @@ class Resource implements ResourceInterface
      */
     public function create($data)
     {
+        $original = $data;
         if (is_array($data)) {
-            $data = (object) $data;
+            $data = new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
         }
         if (!is_object($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -193,7 +195,7 @@ class Resource implements ResourceInterface
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
-            return $data;
+            return $original;
         }
         return $last;
     }
@@ -217,8 +219,9 @@ class Resource implements ResourceInterface
      */
     public function update($id, $data)
     {
+        $original = $data;
         if (is_array($data)) {
-            $data = (object) $data;
+            $data = new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
         }
         if (!is_object($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -234,7 +237,7 @@ class Resource implements ResourceInterface
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
-            return $data;
+            return $original;
         }
         return $last;
     }
@@ -263,9 +266,10 @@ class Resource implements ResourceInterface
                 gettype($data)
             ));
         }
+        $original = $data;
         array_walk($data, function($value, $key) use(&$data) {
             if (is_array($value)) {
-                $data[$key] = (object) $value;
+                $data[$key] = new ArrayObject($value);
                 return;
             }
 
@@ -276,14 +280,15 @@ class Resource implements ResourceInterface
                 ));
             }
         });
-        $events  = $this->getEventManager();
-        $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
-        $results = $events->triggerUntil($event, function($result) {
+        $data     = new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
+        $events   = $this->getEventManager();
+        $event    = $this->prepareEvent(__FUNCTION__, array('data' => $data));
+        $results  = $events->triggerUntil($event, function($result) {
             return $result instanceof ApiProblem;
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
-            return $data;
+            return $original;
         }
         return $last;
     }
@@ -308,8 +313,9 @@ class Resource implements ResourceInterface
      */
     public function patch($id, $data)
     {
+        $original = $data;
         if (is_array($data)) {
-            $data = (object) $data;
+            $data = new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
         }
         if (!is_object($data)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -325,7 +331,7 @@ class Resource implements ResourceInterface
         });
         $last    = $results->last();
         if (!is_array($last) && !is_object($last)) {
-            return $data;
+            return $original;
         }
         return $last;
     }
@@ -371,6 +377,11 @@ class Resource implements ResourceInterface
                 gettype($data)
             ));
         }
+
+        if (is_array($data)) {
+            $data = new ArrayObject($data, ArrayObject::ARRAY_AS_PROPS);
+        }
+
         $events  = $this->getEventManager();
         $event   = $this->prepareEvent(__FUNCTION__, array('data' => $data));
         $results = $events->triggerUntil($event, function($result) {


### PR DESCRIPTION
As discussed on https://github.com/weierophinney/PhlyRestfully/pull/91, passing data provided as an array through to listeners as an array is desirable, but can cause unexpected behaviour in event handling as arrays are effectively passed by value.

As a compromise, passing an ArrayObject allows most of the advantages of passing an array while allowing the data to be modified by event handlers.

Additionally, in this implementation

* ArrayObjects have been created with ARRAY_AS_PROPS for backwards compatibility with code that expected arrays to be cast to objects.
* Resource actions which previously returned the original data if no response was provided by listeners now return the original data *before* being cast; this is potentially not backwards compatible, as code which passed in an array may be expecting to get back an object but will not.