### PR TITLE
Invalid Type Comparison on the Route-Identifier

### DIFF
--- a/src/PhlyRestfully/ResourceController.php
+++ b/src/PhlyRestfully/ResourceController.php
@@ -681,12 +681,12 @@ class ResourceController extends AbstractRestfulController
     {
         $identifier = $this->getIdentifierName();
         $id = $routeMatch->getParam($identifier, false);
-        if ($id) {
+        if ($id !== false) {
             return $id;
         }
 
         $id = $request->getQuery()->get($identifier, false);
-        if ($id) {
+        if ($id !== false) {
             return $id;
         }
 

--- a/test/PhlyRestfullyTest/ResourceControllerTest.php
+++ b/test/PhlyRestfullyTest/ResourceControllerTest.php
@@ -1022,6 +1022,20 @@ class ResourceControllerTest extends TestCase
         $result = $getIdentifier->invoke($this->controller, $routeMatch, $request);
         $this->assertEquals('bar', $result);
     }
+    
+    public function testIdentifierMatchedAgainstParameter()
+    {
+        $r = new ReflectionObject($this->controller);
+        $getIdentifier = $r->getMethod('getIdentifier');
+        $getIdentifier->setAccessible(true);
+
+        $routeMatch = $this->event->getRouteMatch();
+        $request    = $this->controller->getRequest();
+
+        $routeMatch->setParam('id', '0');
+        $result = $getIdentifier->invoke($this->controller, $routeMatch, $request);
+        $this->assertEquals('0', $result);
+    }
 
     /**
      * @group 44


### PR DESCRIPTION
Hey, the "getIdentifier" method at the ResourceController should be check the identifier with the "Not identical" Comparison Operator "if($id !== false)" - like the original zend method - because th identifier could be a string "0" and the method would return false.