### PR TITLE
Update getIdentifier function to support $id = 0

### DIFF
--- a/src/PhlyRestfully/Plugin/HalLinks.php
+++ b/src/PhlyRestfully/Plugin/HalLinks.php
@@ -541,21 +541,21 @@ class HalLinks extends AbstractHelper implements
         }
         $data = $hydrator->extract($object);
 
-        $identiferName = $metadata->getIdentifierName();
-        if (!isset($data[$identiferName])) {
+        $identifierName = $metadata->getIdentifierName();
+        if (!isset($data[$identifierName])) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to determine identifier for object of type "%s"; no fields matching "%s"',
                 get_class($object),
-                $identiferName
+                $identifierName
             ));
         }
-        $id = $data[$identiferName];
+        $id = $data[$identifierName];
 
         $resource = new HalResource($data, $id);
         $links    = $resource->getLinks();
         $this->marshalMetadataLinks($metadata, $links);
         if (!$links->has('self')) {
-            $link = $this->marshalSelfLinkFromMetadata($metadata, $object, $id, $identiferName);
+            $link = $this->marshalSelfLinkFromMetadata($metadata, $object, $id, $identifierName);
             $links->add($link);
         }
 
@@ -597,7 +597,7 @@ class HalLinks extends AbstractHelper implements
      *
      * @param  HalCollection|array|object $collection
      * @param  null|string $route
-     * @param  string $identiferName
+     * @param  string $identifierName
      * @return HalCollection
      */
     public function createCollection($collection, $route = null)

--- a/src/PhlyRestfully/ResourceController.php
+++ b/src/PhlyRestfully/ResourceController.php
@@ -681,7 +681,7 @@ class ResourceController extends AbstractRestfulController
     {
         $identifier = $this->getIdentifierName();
         $id = $routeMatch->getParam($identifier, false);
-        if ($id) {
+        if ($id !== false) {
             return $id;
         }
 


### PR DESCRIPTION
Update getIdentifier function to support $id = 0
Changed if clause to explicitly check for $id not being false.
Previously when $id is set to int 0 the getIdentifier function results
in returning false which is wrong. It should return the integer 0.