### PR TITLE
Allow the default controller class to be specified.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,10 +7,9 @@
  */
 
 return array(
-    'phlyrestfully'        => array(
-        'renderer'         => array(),
-        'resources'        => array(),
-        'controller_class' => 'PhlyRestfully\ResourceController',
+    'phlyrestfully' => array(
+        'renderer'  => array(),
+        'resources' => array(),
     ),
 
     'service_manager' => array(

--- a/src/PhlyRestfully/Factory/ResourceControllerFactory.php
+++ b/src/PhlyRestfully/Factory/ResourceControllerFactory.php
@@ -81,9 +81,12 @@ class ResourceControllerFactory implements AbstractFactoryInterface
      */
     public function createServiceWithName(ServiceLocatorInterface $controllers, $name, $requestedName)
     {
-        $services = $controllers->getServiceLocator();
-        $config   = $services->get('Config');
-        $config   = $config['phlyrestfully']['resources'][$requestedName];
+        $services               = $controllers->getServiceLocator();
+        $config                 = $services->get('Config');
+        $defaultControllerClass = isset($config['phlyrestfully']['default_controller_class'])
+            ? $config['phlyrestfully']['default_controller_class']
+            : 'PhlyRestfully\ResourceController';
+        $config                 = $config['phlyrestfully']['resources'][$requestedName];
 
         if ($services->has($config['listener'])) {
             $listener = $services->get($config['listener']);
@@ -120,7 +123,7 @@ class ResourceControllerFactory implements AbstractFactoryInterface
         }
 
         $events          = $services->get('EventManager');
-        $controllerClass = isset($config['controller_class']) ? $config['controller_class'] : 'PhlyRestfully\ResourceController';
+        $controllerClass = isset($config['controller_class']) ? $config['controller_class'] : $defaultControllerClass;
         $controller      = new $controllerClass($identifier);
 
         if (!$controller instanceof ResourceController) {

--- a/test/PhlyRestfullyTest/Factory/ResourceControllerFactoryTest.php
+++ b/test/PhlyRestfullyTest/Factory/ResourceControllerFactoryTest.php
@@ -66,4 +66,25 @@ class ResourceControllerFactoryTest extends TestCase
         $controller = $this->controllers->get('ApiController');
         $this->assertInstanceOf('PhlyRestfullyTest\Factory\TestAsset\CustomController', $controller);
     }
+
+    public function testWillInstantiateDefaultResourceControllerWhenSpecified()
+    {
+        $config = $this->services->get('Config');
+        $config['phlyrestfully']['default_controller_class'] = 'PhlyRestfullyTest\Factory\TestAsset\CustomController';
+        $this->services->setAllowOverride(true);
+        $this->services->setService('Config', $config);
+        $controller = $this->controllers->get('ApiController');
+        $this->assertInstanceOf('PhlyRestfullyTest\Factory\TestAsset\CustomController', $controller);
+    }
+
+    public function testWillInstantiateAlternateResourceControllerWhenSpecifiedWithDefaultResourceController()
+    {
+        $config = $this->services->get('Config');
+        $config['phlyrestfully']['resources']['ApiController']['controller_class'] = 'PhlyRestfullyTest\Factory\TestAsset\CustomController';
+        $config['phlyrestfully']['default_controller_class'] = 'PhlyRestfully\ResourceController';
+        $this->services->setAllowOverride(true);
+        $this->services->setService('Config', $config);
+        $controller = $this->controllers->get('ApiController');
+        $this->assertInstanceOf('PhlyRestfullyTest\Factory\TestAsset\CustomController', $controller, 'The resource controller should be used instead of the global default controller.');
+    }
 }


### PR DESCRIPTION
Currently each resource can have a separate controller class specified, but there is no way to specify a default controller class to use where this is not specified; it's hard coded to PhlyRestfully\ResourceController.

This patch allows a global default controller class to be specified and defaults to PhlyRestfully\ResourceController if this is not specified.