### PR TITLE
Add magic method __isset method to HalResource

### DIFF
--- a/src/PhlyRestfully/HalResource.php
+++ b/src/PhlyRestfully/HalResource.php
@@ -34,6 +34,30 @@ class HalResource implements LinkCollectionAwareInterface
         $this->id          = $id;
     }
 
+   /**
+     * Check if properties are set
+     *
+     * @param  string $name
+     * @throws Exception\InvalidArgumentException
+     * @return mixed
+     */
+    public function __isset($name)
+    {
+        $names = array(
+            'resource'     => 'resource',
+            'id'           => 'id',
+        );
+        $name = strtolower($name);
+        if (!in_array($name, array_keys($names))) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'Invalid property name "%s"',
+                $name
+            ));
+        }
+        $prop = $names[$name];
+        return $this->{$prop};
+    }
+
     /**
      * Retrieve properties
      *


### PR DESCRIPTION
To be able to use the isset function in the getIdFromResource method (line 154 in HalLinks) there needs to be a magic __isset method inside the HalResource.
Right now the isset always returns false even if the 'id' is set in $resource. This can be considered a bug.